### PR TITLE
Add user personas documentation

### DIFF
--- a/docs/ux/user-personas.md
+++ b/docs/ux/user-personas.md
@@ -1,0 +1,33 @@
+# User Personas
+
+This document describes the main user profiles for MyMusicWall. Personas are used to guide UX, functional scope, and design decisions.
+
+## Persona 1 — The casual listener
+
+**Goals**
+* Keep track of albums listened, liked
+* Quickly browse a visual collection
+
+**Motivations**
+* Enjoy album artwork
+* Rediscover albums easily
+
+**Pain points**
+* Existing apps are too complex
+* Too many clicks for simple actions
+
+## Persona 2 — The music enthusiast
+
+**Goals**
+* Build a personal album library
+* Organize albums visually
+* Make personalized album lists
+
+**Motivations**
+* Strong attachment to album artwork
+* Enjoys collecting and organizing music
+
+**Pain points**
+* Lack of visual-first tools
+* Too many features
+* Cluttered interfaces


### PR DESCRIPTION
## Summary

This pull request adds the user personas documentation for **MyMusicWall**.

The personas describe the main user profiles targeted by the application and are intended to guide UX, functional scope, and future design decisions.

---

## What’s included

- Definition of two primary user personas:
  - The casual listener
  - The music enthusiast
- Description of goals, motivations, and pain points for each persona
- Documentation aligned with the project specifications

---

## Purpose

The purpose of this PR is to better define *who* the application is built for before moving further into functional analysis and implementation.

These personas will serve as a reference when defining use cases, UX flows, and prioritizing features.

---

## Next steps

- Define use cases based on the identified personas
- Map user flows and interactions

Closes #22 